### PR TITLE
be more lenient in accepting Naga titles

### DIFF
--- a/naga_disablekbd.pl
+++ b/naga_disablekbd.pl
@@ -8,7 +8,7 @@ my @lines = split("\n", $linesString);
 
 for(my $i =0; $i < @lines; $i++){
 	my $l = $lines[$i];
-	if($l =~ /Razer Naga\s+id=(\d+).+keyboard/c){
+	if($l =~ /Razer Naga.*id=(\d+).+keyboard/c){
 		# found the keyboard input
 		my $id = $1;
 		system("xinput set-int-prop $id \"Device Enabled\" 8 0");


### PR DESCRIPTION
"Razer Naga 2014" is apparently a new string used to identify this device. Was getting ruled out by the regex here.
